### PR TITLE
Fix fatal error if Gravity Forms or Gravity Flow are deactivated

### DIFF
--- a/blocks.php
+++ b/blocks.php
@@ -15,7 +15,7 @@
 defined( 'ABSPATH' ) || exit;
 
 
-add_action( 'init', array( 'Gravity_Flow_Blocks_Bootstrap', 'load' ), 100 );
+add_action( 'gravityflow_loaded', array( 'Gravity_Flow_Blocks_Bootstrap', 'load' ) );
 
 /**
  * Class Gravity_Flow_Bootstrap
@@ -35,6 +35,12 @@ class Gravity_Flow_Blocks_Bootstrap {
 		include __DIR__ . '/lib/class-controller-inbox-forms.php';
 
 		add_action( 'rest_api_init', array( 'Gravity_Flow_Blocks_Bootstrap', 'register_rest_routes' ) );
+
+		// Enqueue JS and CSS.
+		include __DIR__ . '/lib/enqueue-scripts.php';
+		include __DIR__ . '/blocks/inbox/index.php';
+		include __DIR__ . '/blocks/status/index.php';
+		include __DIR__ . '/blocks/submit/index.php';
 	}
 
 	/**
@@ -55,16 +61,6 @@ class Gravity_Flow_Blocks_Bootstrap {
 	}
 
 }
-
-// Enqueue JS and CSS
-
-include __DIR__ . '/lib/enqueue-scripts.php';
-
-include __DIR__ . '/blocks/inbox/index.php';
-
-include __DIR__ . '/blocks/status/index.php';
-
-include __DIR__ . '/blocks/submit/index.php';
 
 /**
  * Gets this plugin's absolute directory path.

--- a/blocks/inbox/index.php
+++ b/blocks/inbox/index.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'plugins_loaded', 'gravityflow_register_inbox_dynamic_block' );
+add_action( 'init', 'gravityflow_register_inbox_dynamic_block' );
 /**
  * Register the dynamic block.
  *

--- a/blocks/status/index.php
+++ b/blocks/status/index.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'plugins_loaded', 'gravityflow_register_status_block' );
+add_action( 'init', 'gravityflow_register_status_block' );
 /**
  * Register the status block.
  *

--- a/blocks/submit/index.php
+++ b/blocks/submit/index.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'plugins_loaded', 'gravityflow_register_submit_block' );
+add_action( 'init', 'gravityflow_register_submit_block' );
 /**
  * Register the status block.
  *


### PR DESCRIPTION
re: [HS#11470](https://secure.helpscout.net/conversation/999876980/11470?folderId=1113492)

Fixes fatal errors which can occur if Gravity Forms or Gravity Flow are deactivated.

##  Testing Instructions
- Deactivate Gravity Forms and find a fatal error occurs
- Switch to this branch and find the error does not occur
- Check that the inbox, status, and submit blocks are functional in the block editor and when viewing pages containing the blocks
- Deactivate Gravity Flow
- Check that fatal errors do not occur when viewing pages containing the blocks